### PR TITLE
add type for webpack compiler from webpack types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,7 +56,7 @@ declare namespace GrpcWebPlugin {
 
 declare class GrpcWebPlugin {
   constructor(options: GrpcWebPlugin.Options);
-  apply(compiler: Compiler): void;
+  apply(compiler): void;
 }
 
 export = GrpcWebPlugin;


### PR DESCRIPTION
There is a bug in the index.d.ts, where the Compilier type is not defined. This results in an error when building a webpack config file that's written in Typescript.

Repro: 
run `yarn run tsc webpack-config.ts` produces error: 
```
node_modules/grpc-webpack-plugin/index.d.ts:59:19 - error TS2304: Cannot find name 'Compiler'.

59   apply(compiler: Compiler): void;
```

Fix:
add dev dependency on @types/webpack.
import ICompiler type from webpack.
